### PR TITLE
Delete the PG pvc by name

### DIFF
--- a/bin/teardown
+++ b/bin/teardown
@@ -2,6 +2,6 @@
 
 oc delete all -l app=service-portal
 
-oc get pvc -o name |xargs oc delete
+oc delete pvc service-portal-postgresql
 
 oc delete secret -l app=service-portal


### PR DESCRIPTION
This will prevent unintended removal of other pvcs if we are not
the only application in the namespace